### PR TITLE
ci: fix typo and publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,5 +46,5 @@ jobs:
         # [ $(npm show `npm pkg get name | tr -d '"'` version) != $(npm pkg get version | tr -d '"') ]
 
     - name: Publish
-      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' && matrix.node-version == '16.x' }}
+      if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' && matrix.node-version == '16.x' }}
       run: npm publish


### PR DESCRIPTION
The default branch is `main` 🧐 